### PR TITLE
allow definition of pub struct via mock_trait

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -90,6 +90,25 @@ macro_rules! mock_trait {
             }
         }
     );
+
+    (pub $mock_name:ident $(, $method:ident($($arg_type:ty),* ) -> $retval:ty )* ) => (
+        #[derive(Debug, Clone)]
+        pub struct $mock_name {
+            $(
+                $method: double::Mock<(($($arg_type),*)), $retval>
+            ),*
+        }
+
+        impl Default for $mock_name {
+            fn default() -> Self {
+                $mock_name {
+                    $(
+                        $method: double::Mock::default()
+                    ),*
+                }
+            }
+        }
+    );
 }
 
 /// Macro that generates a mock implementation of a `trait` method.


### PR DESCRIPTION
This change allows you to define mock structs with `pub` visibility, which is nice if you want to centrally define a mock struct to be reused in many tests.
 
It looks like this:
```
   mock_trait!(
        pub MockStruct,
        somefunction(String) -> String
    );
```

Sadly the implementation for this involves a lot of duplicate code, but accoring to https://github.com/rust-lang/rust/issues/18317#issuecomment-74743988 and other things I've found, there doesn't seem to be another way to do that.
