### PR TITLE
Remove extra commas in mock_method!

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -329,7 +329,7 @@ macro_rules! mock_method {
 
     // mutable, no return value, no type parameter, no body
     ( $method:ident(&mut self $(,$arg_name:ident: $arg_type:ty)*)) => (
-        fn $method(&mut self $(,$arg_name: $arg_type),*) {
+        fn $method(&mut self $(,$arg_name: $arg_type)*) {
             self.$method.call(($($arg_name.clone()),*))
         }
     );
@@ -350,7 +350,7 @@ macro_rules! mock_method {
 
     // mutable, return value, no type parameter, no body
     ( $method:ident(&mut self $(,$arg_name:ident: $arg_type:ty)*) -> $retval:ty ) => (
-        fn $method(&mut self $(,$arg_name: $arg_type),*) -> $retval {
+        fn $method(&mut self $(,$arg_name: $arg_type)*) -> $retval {
             self.$method.call(($($arg_name.clone()),*))
         }
     );


### PR DESCRIPTION
The extra commas lead to compilation errors on methods that take `&mut self` and more than one parameter.

Minimal example (adapted from `examples/macro.rs`, except `multiply` takes `&mut self` rather than `&self`).

```rust
#[macro_use]
extern crate double;

trait Calculator: Clone {
    fn multiply(&mut self, x: i32, y: i32) -> i32;
}

mock_trait!(
    MockCalculator,
    multiply(i32, i32) -> i32);
impl Calculator for MockCalculator {
    mock_method!(multiply(&mut self, x: i32, y: i32) -> i32);
}

fn main() {
    let mut mock = MockCalculator::default();
    mock.multiply(2, 3);
    assert!(mock.multiply.called_with((2, 3)));
}
```
Compilation error:

```
error: expected pattern, found `,`                                              
  --> poc.rs:12:5                                                               
   |
12 |     mock_method!(multiply(&mut self, x: i32, y: i32) -> i32);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in a macro outside of the current crate

error: expected one of `)`, `-`, `box`, `false`, `mut`, `ref`, or `true`, found `,`
  --> poc.rs:12:5
   |
12 |     mock_method!(multiply(&mut self, x: i32, y: i32) -> i32);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |     |
   |     expected one of 7 possible tokens here
   |     unexpected token
   |
   = note: this error originates in a macro outside of the current crate

error: Could not compile `double`.
```