### PR TITLE
Add mock_trait_no_default! Macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "double"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Donald Whyte <donsoft@donsoft.io>"]
 repository = "https://github.com/DonaldWhyte/double"
 homepage = "https://github.com/DonaldWhyte/double"

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -31,7 +31,35 @@ fn test_doubling_a_sheets_profit() {
     sheet.profit.has_calls_exactly_in_order(vec!((500, 250)));
 }
 
-// Executing test
+// `Result` does not implement the `Default` trait. Trying to mock `UserStore`
+// using the `mock_trait!` macro will fail. We use `mock_trait_no_default!`
+// instead.
+pub trait UserStore {
+    fn get_username(&self, id: i32) -> Result<String, String>;
+}
+
+mock_trait_no_default!(
+    MockUserStore,
+    get_username(i32) -> Result<String, String>);
+
+impl UserStore for MockUserStore {
+    mock_method!(get_username(&self, id: i32) -> Result<String, String>);
+}
+
+fn test_manually_setting_default_retval() {
+    // GIVEN:
+    // Construct instance of the mock, manually specifying the default
+    // return value for `get_username()`.
+    let mock = MockUserStore::new(
+        Ok("default_user_name".to_owned()));
+    // WHEN:
+    let result = mock.get_username(10001);
+    // THEN:
+    assert_eq!(Ok("default_username".to_owned()), result);
+}
+
+// Executing tests
 fn main() {
     test_doubling_a_sheets_profit();
+    test_manually_setting_default_retval();
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,8 +1,8 @@
 // Private macros. They need to be exported and made public so they can be used
 // in the actual public facing macros. Ideally these would be inaccessible to
-// clients, but since that's not possible, we at least make it explicitly that
+// clients, but since that's not possible, we at least make it explicit that
 // these are intended to be private by prepending the macro names with
-// "__private" .
+// "__private".
 #[macro_export]
 macro_rules! __private_mock_trait_default_impl {
     ($mock_name:ident $(, $method:ident)*) => (
@@ -117,6 +117,7 @@ macro_rules! mock_trait {
             ),*
         }
 
+        __private_mock_trait_new_impl!($mock_name $(, $method: $retval)*);
         __private_mock_trait_default_impl!($mock_name $(, $method)*);
     );
 
@@ -128,6 +129,7 @@ macro_rules! mock_trait {
             ),*
         }
 
+        __private_mock_trait_new_impl!($mock_name $(, $method: $retval)*);
         __private_mock_trait_default_impl!($mock_name $(, $method)*);
     );
 }
@@ -220,7 +222,6 @@ macro_rules! mock_trait_no_default {
         }
 
         __private_mock_trait_new_impl!($mock_name $(, $method: $retval)*);
-
     );
 
     (pub $mock_name:ident $(, $method:ident($($arg_type:ty),* ) -> $retval:ty )* ) => (

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,12 +1,49 @@
-/// Macro that generates a `struct` implementation of a specified trait.
+// Private macros. They need to be exported and made public so they can be used
+// in the actual public facing macros. Ideally these would be inaccessible to
+// clients, but since that's not possible, we at least make it explicitly that
+// these are intended to be private by prepending the macro names with
+// "__private" .
+#[macro_export]
+macro_rules! __private_mock_trait_default_impl {
+    ($mock_name:ident $(, $method:ident)*) => (
+         impl Default for $mock_name {
+            fn default() -> Self {
+                Self {
+                    $( $method: double::Mock::default() ),*
+                }
+            }
+        }
+    );
+}
+
+#[macro_export]
+macro_rules! __private_mock_trait_new_impl {
+    ($mock_name:ident $(, $method:ident: $retval: ty)*) => (
+        impl $mock_name {
+            pub fn new( $($method: $retval),* ) -> Self {
+                Self {
+                    $( $method: double::Mock::new($method) ),*
+                }
+            }
+        }
+    );
+}
+
+/// Macro that generates a `struct` implementation of a trait.
+///
+/// Use this instead of `mock_trait_no_default!` if all mocked method return
+/// types implement `Default`. If one or more of the return types do not
+/// implement `Default`, then `mock_trait_no_default!` must be used to generate
+/// the mock.
 ///
 /// This macro generates a `struct` that implements the traits `Clone`, `Debug`
-/// and `Default`. Create instances of the mock object by calling the `struct`'s
-/// `default()` method.
+/// and `Default`. Create instances of the mock object by calling the
+/// `struct`'s `default()` method, or specify custom default return values for
+/// each mocked method using `new()`.
 ///
-/// The `struct` has a field for each method of the `trait`, which manages their
-/// respective method's behaviour and call expectations. For example, if one
-/// defines a mock like so:
+/// The `struct` has a field for each method of the `trait`, which manages
+/// their respective method's behaviour and call expectations. For example, if
+/// one defines a mock like so:
 ///
 /// ```
 /// # #[macro_use] extern crate double;
@@ -80,15 +117,7 @@ macro_rules! mock_trait {
             ),*
         }
 
-        impl Default for $mock_name {
-            fn default() -> Self {
-                $mock_name {
-                    $(
-                        $method: double::Mock::default()
-                    ),*
-                }
-            }
-        }
+        __private_mock_trait_default_impl!($mock_name $(, $method)*);
     );
 
     (pub $mock_name:ident $(, $method:ident($($arg_type:ty),* ) -> $retval:ty )* ) => (
@@ -99,15 +128,110 @@ macro_rules! mock_trait {
             ),*
         }
 
-        impl Default for $mock_name {
-            fn default() -> Self {
-                $mock_name {
-                    $(
-                        $method: double::Mock::default()
-                    ),*
-                }
-            }
+        __private_mock_trait_default_impl!($mock_name $(, $method)*);
+    );
+}
+
+/// Macro that generates a `struct` implementation of a trait.
+///
+/// Use this instead of `mock_trait!` if one or more of the return types do not
+/// implement `Default`. If all return types implement `Default`, then it's
+/// more convenient to use `mock_trait!`, since you instantiate mock objects
+/// using `default()`,
+///
+/// This macro generates a `struct` that implements the traits `Clone` and
+/// and `Debug`. Create instances of the mock object by calling `new()`,
+/// passing in the return values for each mocked method using `new()`.
+///
+/// The `struct` has a field for each method of the `trait`, which manages
+/// their respective method's behaviour and call expectations. For example, if
+/// one defines a mock like so:
+//
+/// ```
+/// # #[macro_use] extern crate double;
+///
+/// // `Result` does not implement `Default`.
+/// mock_trait_no_default!(
+///     MockTaskManager,
+///     max_threads(()) -> Result<u32, String>,
+///     set_max_threads(u32) -> ()
+/// );
+///
+/// # fn main() {
+///     // only here to make `cargo test` happy
+/// }
+/// ```
+///
+/// Then the following code is generated:
+///
+/// ```
+/// #[derive(Debug, Clone)]
+/// struct MockTaskManager {
+///     max_threads: double::Mock<(), Result<u32, String>>,
+///     set_max_threads: double::Mock<(u32), ()>,
+/// }
+///
+/// impl MockTaskManager {
+///     pub fn new(max_threads: Result<u32, String>, set_max_threads: ()) -> Self {
+///         MockTaskManager {
+///             max_threads: double::Mock::new(max_threads),
+///             set_max_threads: double::Mock::new(set_max_threads),
+///         }
+///     }
+/// }
+/// ```
+///
+/// Note that just defining this macro is not enough. This macro is used to
+/// generate the necessary boilerplate, but the generated struct *does not*
+/// implement the desired `trait`. To do that, use `double`'s `mock_method`
+/// macro.
+///
+/// # Examples
+///
+/// ```
+/// # #[macro_use] extern crate double;
+///
+/// trait TaskManager {
+///    fn max_threads(&self) -> Result<u32, String>;
+///    fn set_max_threads(&mut self, max_threads: u32);
+/// }
+///
+/// mock_trait_no_default!(
+///     MockTaskManager,
+///     max_threads(()) -> Result<u32, String>,
+///     set_max_threads(u32) -> ()
+/// );
+///
+/// # fn main() {
+/// let mock = MockTaskManager::new(Ok(42), ());
+/// assert_eq!(Ok(42), mock.max_threads.call(()));
+/// mock.set_max_threads.call(9001u32);
+/// assert!(mock.set_max_threads.called_with(9001u32));
+/// # }
+/// ```
+#[macro_export]
+macro_rules! mock_trait_no_default {
+    ($mock_name:ident $(, $method:ident($($arg_type:ty),* ) -> $retval:ty )* ) => (
+        #[derive(Debug, Clone)]
+        struct $mock_name {
+            $(
+                $method: double::Mock<(($($arg_type),*)), $retval>
+            ),*
         }
+
+        __private_mock_trait_new_impl!($mock_name $(, $method: $retval)*);
+
+    );
+
+    (pub $mock_name:ident $(, $method:ident($($arg_type:ty),* ) -> $retval:ty )* ) => (
+        #[derive(Debug, Clone)]
+        pub struct $mock_name {
+            $(
+                $method: double::Mock<(($($arg_type),*)), $retval>
+            ),*
+        }
+
+        __private_mock_trait_new_impl!($mock_name $(, $method: $retval)*);
     );
 }
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -28,7 +28,8 @@ pub struct Mock<C, R>
     return_values: Ref<HashMap<C, R>>,
     fns: Ref<HashMap<C, fn(C) -> R>>,
     closures: Ref<HashMap<C, Box<Fn(C) -> R>>>,
-    calls: Ref<Vec<C>>
+
+    calls: Ref<Vec<C>>,
 }
 
 impl<C, R> Mock<C, R>
@@ -102,7 +103,7 @@ impl<C, R> Mock<C, R>
 
         if let Some(ref closure) = self.closures.borrow().get(&args) {
             return closure(args)
-        } else if  let Some(ref function) = self.fns.borrow().get(&args) {
+        } else if let Some(ref function) = self.fns.borrow().get(&args) {
             return function(args)
         } else if let Some(return_value) = self.return_values.borrow().get(&args) {
             return return_value.clone()
@@ -425,6 +426,7 @@ impl<C, R> Mock<C, R>
     }
 }
 
+// TODO: only implement this if there is a `Default` impl in R?
 impl<C, R> Default for Mock<C, R>
     where C: Clone + Eq + Hash,
           R: Clone + Default


### PR DESCRIPTION
Add `mock_trait_no_default!` macro to allow clients to mock trait methods that return values whose types do not implement the `Default` trait.