### PR TITLE
Rust 2018 Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ These behaviours are configured by invoking methods on the mock objects themselv
 
 | Method | What It Does |
 | ------ | ------------ |
-| `use_fn_for((args), Fn(...) -> retval)` | invoke given function and return the value it returns when specified `(args)` are passed in |
-| `use_closure_for((args), &Fn(...) -> retval)` | invoke given closure and return the value it returns when specified `(args)` are passed in |
+| `use_fn_for((args), dyn Fn(...) -> retval)` | invoke given function and return the value it returns when specified `(args)` are passed in |
+| `use_closure_for((args), &dyn Fn(...) -> retval)` | invoke given closure and return the value it returns when specified `(args)` are passed in |
 | `return_value_for((args), val)` | return `val` when specified `(args)` are passed in |
-| `use_fn(Fn(...) -> retval)` | invoke given function and return the value it returns by default |
-| `use_closure(&Fn(...) -> retval)` | invoke given closure and return the value it returns by default |
+| `use_fn(dyn Fn(...) -> retval)` | invoke given function and return the value it returns by default |
+| `use_closure(&dyn Fn(...) -> retval)` | invoke given closure and return the value it returns by default |
 | `return_values(vec<retval>)` | return values in given vector by default, return one value for each invocation of the mock method. If there are no more values in the vector, return the default value specified by `return_value()`  |
 | `return_value(val)` | return `val` by default |
 
@@ -653,7 +653,7 @@ The authors of double argue that reimplenting the aforementined features is more
 `double::Mock` objects can also be used for free functions. Consider the following function:
 
 ```rust
-fn generate_sequence(func: &Fn(i32) -> i32, min: i32, max: i32) -> Vec<i32> {
+fn generate_sequence(func: &dyn Fn(i32) -> i32, min: i32, max: i32) -> Vec<i32> {
     // exclusive range
     (min..max).map(func).collect()
 }
@@ -667,7 +667,7 @@ Rather than generate your own mock transformation function boilerplate when test
 #[macro_use]
 extern crate double;
 
-fn generate_sequence(func: &Fn(i32) -> i32, min: i32, max: i32) -> Vec<i32> {
+fn generate_sequence(func: &dyn Fn(i32) -> i32, min: i32, max: i32) -> Vec<i32> {
     // exclusive range
     (min..max).map(func).collect()
 }

--- a/build.rs
+++ b/build.rs
@@ -71,7 +71,7 @@ fn generate_match_impl_n(n_args: usize) -> String {
     // the input arg as a one-tuple and will treat it is a single arg instead.
     if n_args == 1 {
         return "
-pub fn match_impl_1<A>(arg: &A, arg_matcher: &Fn(&A) -> bool) -> bool {
+pub fn match_impl_1<A>(arg: &A, arg_matcher: &dyn Fn(&A) -> bool) -> bool {
     arg_matcher(arg)
 }".to_owned();
     }
@@ -85,7 +85,7 @@ pub fn match_impl_1<A>(arg: &A, arg_matcher: &Fn(&A) -> bool) -> bool {
     ).collect();
 
     let matcher_params: Vec<String> = type_param_names.iter().map(
-        |ref t| format!("&Fn(&{}) -> bool", t)
+        |ref t| format!("&dyn Fn(&{}) -> bool", t)
     ).collect();
 
     let matcher_invocations: Vec<String> = arg_number_range.iter().map(

--- a/examples/function.rs
+++ b/examples/function.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate double;
 
-fn generate_sequence(func: &Fn(i32) -> i32, min: i32, max: i32) -> Vec<i32> {
+fn generate_sequence(func: &dyn Fn(i32) -> i32, min: i32, max: i32) -> Vec<i32> {
     // exclusive range
     (min..max).map(func).collect()
 }

--- a/examples/macro_new_style_import.rs
+++ b/examples/macro_new_style_import.rs
@@ -1,0 +1,76 @@
+// NOTE: This example is identical to macros.rs. The only difference is that
+// this example imports the double macros using the newer, rust 2018 approach.
+// macros.rs uses the legacy #[macro_use] approach. This one imports the macros
+// being used directly.
+
+extern crate double;
+
+use double::mock_method;
+use double::mock_trait;
+use double::mock_trait_no_default;
+
+// Traits which only return types that implement `Default`.
+trait Calculator: Clone {
+    fn multiply(&self, x: i32, y: i32) -> i32;
+}
+
+trait BalanceSheet: Clone {
+    fn profit(&self, revenue: u32, costs: u32) -> i32;
+    fn loss(&self, revenue: u32, costs: u32) -> i32;
+}
+
+trait Greeter: Clone {
+    fn greet<S: AsRef<str>>(&mut self, name: S);
+}
+
+mock_trait!(EmptyMock);
+
+mock_trait!(
+    MockCalculator,
+    multiply(i32, i32) -> i32);
+impl Calculator for MockCalculator {
+    mock_method!(multiply(&self, x: i32, y: i32) -> i32);
+}
+
+mock_trait!(
+    MockBalanceSheet,
+    profit(u32, u32) -> i32,
+    loss(u32, u32) -> i32);
+impl BalanceSheet for MockBalanceSheet {
+    mock_method!(profit(&self, revenue: u32, costs: u32) -> i32);
+    mock_method!(loss(&self, revenue: u32, costs: u32) -> i32);
+}
+
+mock_trait!(
+    MockGreeter,
+    greet(String) -> ());
+impl Greeter for MockGreeter {
+    mock_method!(greet<(S: AsRef<str>)>(&mut self, name: S), self, {
+        self.greet.call(name.as_ref().to_string());
+    });
+}
+
+// Traits which return types that do not implement `Default`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct User {
+    name: String
+}
+
+pub trait UserStore {
+    fn get_user(&self, id: i32) -> Result<User, String>;
+    fn delete_user(&self, id: i32) -> Result<(), String>;
+}
+
+mock_trait_no_default!(
+    MockUserStore,
+    get_user(i32) -> Result<User, String>,
+    delete_user(i32) -> Result<(), String>);
+
+impl UserStore for MockUserStore {
+    mock_method!(get_user(&self, id: i32) -> Result<User, String>);
+    mock_method!(delete_user(&self, id: i32) -> Result<(), String>);
+}
+
+fn main() {
+
+}

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -6,7 +6,7 @@ trait BalanceSheet {
     fn profit(&self, revenue: u32, costs: u32) -> i32;
 }
 
-fn double_profit(revenue: u32, costs: u32, balance_sheet: &BalanceSheet) -> i32 {
+fn double_profit(revenue: u32, costs: u32, balance_sheet: &dyn BalanceSheet) -> i32 {
     balance_sheet.profit(revenue, costs) * 2
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -122,8 +122,8 @@ macro_rules! mock_trait {
             ),*
         }
 
-        __private_mock_trait_new_impl!($mock_name $(, $method: $retval)*);
-        __private_mock_trait_default_impl!($mock_name $(, $method)*);
+        $crate::__private_mock_trait_new_impl!($mock_name $(, $method: $retval)*);
+        $crate::__private_mock_trait_default_impl!($mock_name $(, $method)*);
     );
 
     (pub $mock_name:ident $(, $method:ident($($arg_type:ty),* ) -> $retval:ty )* ) => (
@@ -134,8 +134,8 @@ macro_rules! mock_trait {
             ),*
         }
 
-        __private_mock_trait_new_impl!($mock_name $(, $method: $retval)*);
-        __private_mock_trait_default_impl!($mock_name $(, $method)*);
+        $crate::__private_mock_trait_new_impl!($mock_name $(, $method: $retval)*);
+        $crate::__private_mock_trait_default_impl!($mock_name $(, $method)*);
     );
 }
 
@@ -226,7 +226,7 @@ macro_rules! mock_trait_no_default {
             ),*
         }
 
-        __private_mock_trait_new_impl!($mock_name $(, $method: $retval)*);
+        $crate::__private_mock_trait_new_impl!($mock_name $(, $method: $retval)*);
     );
 
     (pub $mock_name:ident $(, $method:ident($($arg_type:ty),* ) -> $retval:ty )* ) => (
@@ -237,7 +237,7 @@ macro_rules! mock_trait_no_default {
             ),*
         }
 
-        __private_mock_trait_new_impl!($mock_name $(, $method: $retval)*);
+        $crate::__private_mock_trait_new_impl!($mock_name $(, $method: $retval)*);
     );
 }
 

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -59,7 +59,7 @@ pub fn between_inc<T: PartialEq + PartialOrd>(arg: &T, low: T, high: T) -> bool 
 
 /// Matcher that matches if `arg` is a populated `Option` whose stored value
 /// matches the specified `matcher`.
-pub fn is_some<T>(arg: &Option<T>, matcher: &Fn(&T) -> bool) -> bool {
+pub fn is_some<T>(arg: &Option<T>, matcher: &dyn Fn(&T) -> bool) -> bool {
     match *arg {
         Some(ref x) => matcher(x),
         None => false
@@ -68,7 +68,7 @@ pub fn is_some<T>(arg: &Option<T>, matcher: &Fn(&T) -> bool) -> bool {
 
 /// Matcher that matches if `arg` is a `Result::Ok` whose stored value matches
 /// the specified `matcher`.
-pub fn is_ok<T, U>(arg: &Result<T, U>, matcher: &Fn(&T) -> bool) -> bool {
+pub fn is_ok<T, U>(arg: &Result<T, U>, matcher: &dyn Fn(&T) -> bool) -> bool {
     match *arg {
         Ok(ref x) => matcher(x),
         Err(_) => false
@@ -77,7 +77,7 @@ pub fn is_ok<T, U>(arg: &Result<T, U>, matcher: &Fn(&T) -> bool) -> bool {
 
 /// Matcher that matches if `arg` is a `Result::Err` whose stored value matches
 /// the specified `matcher`.
-pub fn is_err<T, U>(arg: &Result<T, U>, matcher: &Fn(&U) -> bool) -> bool {
+pub fn is_err<T, U>(arg: &Result<T, U>, matcher: &dyn Fn(&U) -> bool) -> bool {
     match *arg {
         Ok(_) => false,
         Err(ref x) => matcher(x)
@@ -179,14 +179,14 @@ pub fn ne_nocase(arg: &str, string: &str) -> bool {
 // ============================================================================
 
 /// Matcher that matches if `arg` does _not_ match the specified `matcher`.
-pub fn not<T>(arg: &T, matcher: &Fn(&T) -> bool) -> bool {
+pub fn not<T>(arg: &T, matcher: &dyn Fn(&T) -> bool) -> bool {
     !matcher(arg)
 }
 
 /// Matcher that matches if `arg` matches *all* of the specified `matchers`. If
 /// at least one of `matchers` doesn't match with `arg`, this matcher doesn't
 /// match.
-pub fn all_of<T>(arg: &T, matchers: Vec<&Fn(&T) -> bool>) -> bool {
+pub fn all_of<T>(arg: &T, matchers: Vec<&dyn Fn(&T) -> bool>) -> bool {
     for matcher in matchers {
         if !matcher(arg) {
             return false
@@ -197,7 +197,7 @@ pub fn all_of<T>(arg: &T, matchers: Vec<&Fn(&T) -> bool>) -> bool {
 
 /// Matcher that matches if `arg` matches *any* of the specified `matchers`. If
 /// none of the `matchers` match with `arg`, this matcher doesn't match.
-pub fn any_of<T>(arg: &T, matchers: Vec<&Fn(&T) -> bool>) -> bool {
+pub fn any_of<T>(arg: &T, matchers: Vec<&dyn Fn(&T) -> bool>) -> bool {
     for matcher in matchers {
         if matcher(arg) {
             return true


### PR DESCRIPTION
* fix new compiler warnings that complains when the `dyn` keyword is not used when a trait symbol is referred to
* make importing double macros using Rust 2018 approach easier by not forcing users to import the private macros too